### PR TITLE
Reduces 500 errors

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- web.config contributed to html5boilerplate by Velir : velir.com -->
 <configuration>
     <configSections>
@@ -114,44 +114,57 @@
       </handlers>
         <urlCompression doStaticCompression="true" />
         <staticContent>
-					<!-- Set expire headers to 30 days for static content-->
-					<clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00" />
-					<!-- use utf-8 encoding for anything served text/plain or text/html -->
-					<remove fileExtension=".css" />
-					<mimeMap fileExtension=".css" mimeType="text/css; charset=UTF-8" />
-					<remove fileExtension=".js" />
-					<mimeMap fileExtension=".js" mimeType="text/javascript; charset=UTF-8" />
-					<remove fileExtension=".json" />
-					<mimeMap fileExtension=".json" mimeType="application/json; charset=UTF-8" />
-					<remove fileExtension=".rss" />
-					<mimeMap fileExtension=".rss" mimeType="application/rss+xml; charset=UTF-8" />
-					<remove fileExtension=".html" />
-					<mimeMap fileExtension=".html" mimeType="text/html; charset=UTF-8" />
-					<remove fileExtension=".xml" />
-					<mimeMap fileExtension=".xml" mimeType="application/xml; charset=UTF-8" />
-					<!-- HTML5 Video mime types-->
-					<mimeMap fileExtension=".mp4" mimeType="video/mp4" />
-					<mimeMap fileExtension=".m4v" mimeType="video/m4v" />
-					<mimeMap fileExtension=".ogg" mimeType="video/ogg" />
-					<mimeMap fileExtension=".ogv" mimeType="video/ogg" />
-					<mimeMap fileExtension=".webm" mimeType="video/webm" />
-					<!-- Proper svg serving. Required for svg webfonts on iPad -->
-					<mimeMap fileExtension=".svg" mimeType="images/svg+xml" />
-					<mimeMap fileExtension=".svgz" mimeType="images/svg+xml" />
-					<!-- HTML4 Web font mime types -->
-					<!-- Remove default IIS mime type for .eot which is application/octet-stream -->
-					<remove fileExtension=".eot" />
-					<mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
-					<mimeMap fileExtension=".otf" mimeType="font/otf" />
-					<mimeMap fileExtension=".woff" mimeType="font/x-woff" />
-					<mimeMap fileExtension=".crx" mimeType="application/x-chrome-extension" />
-					<mimeMap fileExtension=".xpi" mimeType="application/x-xpinstall" />
-					<mimeMap fileExtension=".safariextz" mimeType="application/octet-stream" />
-					<!-- Flash Video mime types-->
-					<mimeMap fileExtension=".flv" mimeType="video/x-flv" />
-					<mimeMap fileExtension=".f4v" mimeType="video/mp4" />
-					
-				</staticContent>
+          <!-- Set expire headers to 30 days for static content-->
+          <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00"/>
+          <!-- use utf-8 encoding for anything served text/plain or text/html -->
+          <remove fileExtension=".css" />
+          <mimeMap fileExtension=".css" mimeType="text/css; charset=UTF-8" />
+          <remove fileExtension=".js" />
+          <mimeMap fileExtension=".js" mimeType="text/javascript; charset=UTF-8" />
+          <remove fileExtension=".json" />
+          <mimeMap fileExtension=".json" mimeType="application/json; charset=UTF-8" />
+          <remove fileExtension=".rss" />
+          <mimeMap fileExtension=".rss" mimeType="application/rss+xml; charset=UTF-8" />
+          <remove fileExtension=".html" />
+          <mimeMap fileExtension=".html" mimeType="text/html; charset=UTF-8" />
+          <remove fileExtension=".xml" />
+          <mimeMap fileExtension=".xml" mimeType="application/xml; charset=UTF-8" />
+          <!-- HTML5 Audio/Video mime types-->
+          <remove fileExtension=".mp3" />
+          <mimeMap fileExtension=".mp3" mimeType="audio/mpeg" />
+          <remove fileExtension=".mp4" />
+          <mimeMap fileExtension=".mp4" mimeType="video/mp4" />
+          <remove fileExtension=".ogg" />
+          <mimeMap fileExtension=".ogg" mimeType="audio/ogg" />
+          <remove fileExtension=".ogv" />
+          <mimeMap fileExtension=".ogv" mimeType="video/ogg" />
+          <remove fileExtension=".webm" />
+          <mimeMap fileExtension=".webm" mimeType="video/webm" />
+          <!-- Proper svg serving. Required for svg webfonts on iPad -->
+          <remove fileExtension=".svg" />
+          <mimeMap fileExtension=".svg" mimeType="images/svg+xml" />
+          <remove fileExtension=".svgz" />
+          <mimeMap fileExtension=".svgz" mimeType="images/svg+xml" />
+          <!-- HTML4 Web font mime types -->
+          <!-- Remove default IIS mime type for .eot which is application/octet-stream -->
+          <remove fileExtension=".eot" />
+          <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
+          <remove fileExtension=".otf" />
+          <mimeMap fileExtension=".otf" mimeType="font/otf" />
+          <remove fileExtension=".woff" />
+          <mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+          <remove fileExtension=".crx" />
+          <mimeMap fileExtension=".crx" mimeType="application/x-chrome-extension" />
+          <remove fileExtension=".xpi" />
+          <mimeMap fileExtension=".xpi" mimeType="application/x-xpinstall" />
+          <remove fileExtension=".safariextz" />
+          <mimeMap fileExtension=".safariextz" mimeType="application/octet-stream" />
+          <!-- Flash Video mime types-->
+          <remove fileExtension=".flv" />
+          <mimeMap fileExtension=".flv" mimeType="video/x-flv" />
+          <remove fileExtension=".f4v" />
+          <mimeMap fileExtension=".f4v" mimeType="video/mp4" />
+        </staticContent>
         <httpProtocol>
             <customHeaders>
 				<!-- 


### PR DESCRIPTION
the change was to include <remove> elements before any new mimeMap definitions to prevent some web hosts from throwing http 500 errors.
