### PR TITLE
Save disk writes for static file access

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -114,7 +114,7 @@ http {
     location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
       expires max;
       root   /sites/example.com/public;
-      access_log logs/static.log;
+      access_log off;
     }
 
     # opt-in to the future


### PR DESCRIPTION
Save disc writes, and essentially time, by not logging access for static files.
