### PR TITLE
 CSS didn't get loaded with a mimeMap that had a UTF8 string in the mimetype attribute

### DIFF
--- a/web.config
+++ b/web.config
@@ -118,11 +118,11 @@
           <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00"/>
           <!-- use utf-8 encoding for anything served text/plain or text/html -->
           <remove fileExtension=".css" />
-          <mimeMap fileExtension=".css" mimeType="text/css; charset=UTF-8" />
+          <mimeMap fileExtension=".css" mimeType="text/css" />
           <remove fileExtension=".js" />
-          <mimeMap fileExtension=".js" mimeType="text/javascript; charset=UTF-8" />
+          <mimeMap fileExtension=".js" mimeType="text/javascript" />
           <remove fileExtension=".json" />
-          <mimeMap fileExtension=".json" mimeType="application/json; charset=UTF-8" />
+          <mimeMap fileExtension=".json" mimeType="application/json />
           <remove fileExtension=".rss" />
           <mimeMap fileExtension=".rss" mimeType="application/rss+xml; charset=UTF-8" />
           <remove fileExtension=".html" />


### PR DESCRIPTION
I've only changed the mimeMaps that seem to me to be text files.
xml files like text/html application/rss+xml and application/xml probably should be served as UTF8. They work in any case.
