### PR TITLE
updated App Engine app.yaml to include many of the mime-types and expiration exceptions from .htaccess

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 # boilerplate server config for google app engine
-# from darktable aka Calvin Rein
+# from darktable aka Calvin Rien
 # http://forrst.com/posts/Host_a_Static_HTML_Site_on_Google_App_Engine-BlA
 # 
 # Note: file names are case-sensitive and spaces in paths is not supported.
@@ -181,7 +181,7 @@ handlers:
   upload: static/(.*\.xpi)
 
 # image files
-- url: /(.*\.(bmp|gif|ico|jpeg|jpg|png))
+- url: /(.*\.(bmp|gif|jpeg|jpg|png))
   static_files: static/\1
   upload: static/(.*\.(bmp|gif|jpeg|jpg|png))
 


### PR DESCRIPTION
I tried to match the functionality of the .htaccess file as much as possible (mime-types served, and expiration header overrides).  Static .css, .js and image files will work outside of /css/,/js/, and /img/ directories (for people with sloppy site structure).

Also, after creating that first app.yaml I discovered a way to serve a static site in App Engine without any python files at all.  That is included in here in a block that is commented out.
