### PR TITLE
Correct Woff Mime Type for web.config

### DIFF
--- a/web.config
+++ b/web.config
@@ -152,7 +152,7 @@
           <remove fileExtension=".otf" />
           <mimeMap fileExtension=".otf" mimeType="font/otf" />
           <remove fileExtension=".woff" />
-          <mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+          <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
           <remove fileExtension=".crx" />
           <mimeMap fileExtension=".crx" mimeType="application/x-chrome-extension" />
           <remove fileExtension=".xpi" />


### PR DESCRIPTION
Changed the mime type of woff as to not show "Resource interpreted as font but transferred with MIME type xyz" in the console.
