### PR TITLE
add mime type for .wav files

### DIFF
--- a/nginx-mime.types
+++ b/nginx-mime.types
@@ -63,6 +63,7 @@ types {
     audio/mpeg                            mp3;
     audio/x-realaudio                     ra;
     audio/ogg                             oga ogg;
+    audio/x-wav                           wav;
 
     video/3gpp                            3gpp 3gp;
     video/mpeg                            mpeg mpg;


### PR DESCRIPTION
apache returns 'audio/x-wav' too:

http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types

but could also be 'audio/wav' or 'audio/wave' or 'audio/vnd.wav' according to wikipedia:

http://en.wikipedia.org/wiki/WAV
