### PR TITLE
nginx - do not set a default expire header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -101,15 +101,6 @@ http {
     # Custom 404 page
     error_page 404 /404.html;
 
-    # This is pretty long expiry and assume your using
-    # cachebusting with query params like
-    #   <script src="application.js?20110529">
-    #
-    # Just be careful if your using this on a frequently
-    # updated static site. You may want to crank this back
-    # to 5m which is 5 minutes.
-    expires 1M; # yes one month
-
     # Static assets
     location ~* ^.+\.(manifest|appcache)$ {
       expires -1;
@@ -118,7 +109,15 @@ http {
 
     # Set expires max on static file types (make sure you are using cache busting filenames or query params):
     location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
-      expires max;
+      # This is pretty long expiry and assume your using
+      # cachebusting with query params like
+      #   <script src="application.js?20110529">
+      #
+      # Just be careful if your using this on a frequently
+      # updated static site. You may want to crank this back
+      # to 5m which is 5 minutes.
+      expires 1M; # yes one month
+
       access_log off;
     }
 


### PR DESCRIPTION
## In Short

The current expire logic for nginx is:
- By default any and all requests expire in a month
- manifest and appcache requests are served already-expired
- Except css/js/images/assets which don't expire

Setting a default expire will interfere with any dynamic page content - for this reason I suggest to remove this expire rule. It's not obvious at a glance (or maybe it is and I'm just too noob from time to time) that the existing default rule will literally apply to all requests to the server. The comment that I have moved also implies it's in the wrong place, the example given is a js file yet the default expire rule will never apply to a js file as it would be captured and overriden by the next ruleset.
## Consistency

This leads to another point, and that is consistency. It's a while since I've used anything except nginx, but:

lighttpd
- static files don't expire
- Catchall to expire any other request in a month

web.config
- No default expire in the config file
- static files don't expire

node.js
- ~~No expire logic in the config file~~
- Edit: static files are cached for 1 month

gae
- Default expire of 30days
- atom expires in an hour
- html expires in an hour
- ico expires in 7days
- json expires in 1hour
- rss expires in 1hour

apache (from h5bp, naturally)
- Default expire of 1 month
- appcache expires immediately
- html expires immediately
- xml expires immediately
- json expires immediately
- atom expires in an hour
- rss expires in an hour
- ico expires in 7days
- css and js expire in a year
- other assets expire in a month

It doesn't seem logical that changing webserver and chosing the appropriate h5bp server config file completely changes the expire logic applied.

Therefore as a follow up to this pull request I propose to action this comment: https://github.com/h5bp/html5-boilerplate/commit/4e17c6dc#L0R96 and then use the apache config as the canonical expire logic which other configs should replicate as close as possible.
