### PR TITLE
Make nginx expire logic consistent with apache config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -101,24 +101,44 @@ http {
     # Custom 404 page
     error_page 404 /404.html;
 
-    # Static assets
-    location ~* ^.+\.(manifest|appcache)$ {
+    # No default expire rule. This config mirrors that of apache as outlined in the
+    # html5-boilerplate .htaccess file. However, nginx applies rules by location, the apache rules
+    # are defined by type. A concequence of this difference is that if you use no file extension in
+    # the url and serve html, with apache you get an expire time of 0s, with nginx you'd get an
+    # expire header of one month in the future (if the default expire rule is 1 month).
+    # Therefore, do not use a default expire rule with nginx unless your site is completely static
+
+    # cache.appcache, your document html and data
+    location ~* \.(?:manifest|appcache|html|xml|json)$ {
       expires -1;
       access_log logs/static.log;
     }
 
-    # Set expires max on static file types (make sure you are using cache busting filenames or query params):
-    location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
-      # This is pretty long expiry and assume your using
-      # cachebusting with query params like
-      #   <script src="application.js?20110529">
-      #
-      # Just be careful if your using this on a frequently
-      # updated static site. You may want to crank this back
-      # to 5m which is 5 minutes.
-      expires 1M; # yes one month
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+      expires 1h;
+      add_header Cache-Control "public";
+    }
 
+    # Favicon
+    location ~* \.ico$ {
+      expires 1w;
       access_log off;
+      add_header Cache-Control "public";
+    }
+
+    # Media: images, video, audio, HTC, WebFonts
+    location ~* \.(?:jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
+      expires 1M;
+      access_log off;
+      add_header Cache-Control "public";
+    }
+
+    # CSS and Javascript
+    location ~* \.(?:css|js)$ {
+      expires 1Y;
+      access_log off;
+      add_header Cache-Control "public";
     }
 
     # opt-in to the future


### PR DESCRIPTION
Following on from #41 - nginx expire logic updated to more closely mimic that of apache.

As I've put in the comments for this file (in part for the benefit of anyone else who subsequently synchronizes these rules with apache's config) it's important to understand that the default expire rule in apache is appropriate - because it only applies to unknown types; whereas a default expire rule in nginx is not appropriate as it applies to unknown types AND anything that isn't a static file (i.e. dynamically generated content - which almost by definition you'd want to have no default expire header set).
