### PR TITLE
 'X-UA-Compatible' header only for users with MSIE

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -141,8 +141,10 @@ http {
       add_header Cache-Control "public";
     }
 
-    # opt-in to the future
-    add_header "X-UA-Compatible" "IE=Edge,chrome=1";
+    # Add X-UA-Compatible header only for IE folk
+    if ($http_user_agent ~ MSIE) {
+      add_header "X-UA-Compatible" "IE=Edge,chrome=1";
+    }
 
   }
 }


### PR DESCRIPTION
We should add 'X-UA-Compatible' header only for users with MSIE useragent.
As Nginx has 'if' directive we can use it to match the useragent.
