### PR TITLE
NGINX – IE5 and IE6 GZIP

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -80,7 +80,7 @@ http {
   # a specific directory:
   # gzip_static on;
 
-  gzip_disable        "MSIE [1-6]\.";
+  gzip_disable        "msie6";
   gzip_vary           on;
 
   server {


### PR DESCRIPTION
IE5 and IE6 are always detected by NGINX, I'm guessing for keepalive reasons. You can see this in the “ngx_http_process_user_agent” function in “http/ngx_http_request.c”.

When deciding whether or not to disable GZIP, NGINX looks for the “msie6” string before moving on to executing regular expressions.
