### PR TITLE
Comment on IIS cache busting suggests wrong filename

### DIFF
--- a/iis/web.config
+++ b/iis/web.config
@@ -245,7 +245,7 @@
 
 			If you're not using the build script to manage your filename version revving,
 			you might want to consider enabling this, which will route requests for
-			/css/style.v20110203.css to /css/style.css
+			/css/style.20110203.css to /css/style.css
 
 			To understand why this is important and a better idea than all.css?v1231,
 			read: github.com/h5bp/html5-boilerplate/wiki/Version-Control-with-Cachebusting


### PR DESCRIPTION
It was suggesting style.v20110203.css instead of style.20110203.css, which is what the rule actually does. Matches the apache config.
