### PR TITLE
Incorrect description in main readme file (IIS version required due to incompatibility of configuration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-
 # [HTML5 Boilerplate](http://html5boilerplate.com) Server Configs
 
 ## Best-practice server configurations for:
 
 * **Apache** The .htaccess config for Apache is actually kept in the original [boilerplate repo](https://github.com/h5bp/html5-boilerplate/)
 * **node.js**
-* **iis**
+* **IIS 7+**
 * **nginx**
 * **lighttpd**
 * **Google AppEngine**
@@ -16,5 +15,5 @@
 
 * [Guide to .htaccess](https://github.com/h5bp/html5-boilerplate/wiki/htaccess) for apache
 * [Guide to node.js](https://github.com/h5bp/server-configs/wiki/node.js) for node.js
-* [Guide to web.config](https://github.com/h5bp/server-configs/wiki/web.config) for IIS
+* [Guide to web.config](https://github.com/h5bp/server-configs/wiki/web.config) for IIS 7+
 * [Guide to nginx.conf](https://github.com/h5bp/server-configs/wiki/nginx.conf) for nginx


### PR DESCRIPTION
Majority of the elements in the web.config would have no affect on IIS6
as the configuration of IIS6 is not affected by the web.server tag
elements. The majority of changes required in IIS6 have to be achieved
manually through metadatabase edits.
