### PR TITLE
Use valid font MIME types

### DIFF
--- a/nginx/mime.types
+++ b/nginx/mime.types
@@ -88,6 +88,6 @@ types {
   # Webfonts
   application/vnd.ms-fontobject         eot;
   application/x-font-ttf                ttf ttc;
-  font/opentype                         otf;
+  application/x-font-opentype           otf;
   application/x-font-woff               woff;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,8 +69,8 @@ http {
     application/json
     application/xml
     application/rss+xml
-    font/truetype
-    font/opentype
+    application/x-font-ttf
+    application/x-font-opentype
     application/vnd.ms-fontobject
     image/svg+xml;
 


### PR DESCRIPTION
`font` isn't a valid top-level MIME type. Instead of inventing a new top-level MIME type, it's better to use the `x-` prefix until fonts get standardised MIME types. 

This change shouldn't break anything, because according the [MDN @font-face](https://developer.mozilla.org/en/css/@font-face#Notes) documentation the MIME type for font files is ignored by the browser.
