### PR TITLE
Update the nginx gzip MIME types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -60,19 +60,17 @@ http {
   gzip_types
     # text/html is always compressed by HttpGzipModule
     text/css
-    text/javascript
-    text/xml
     text/plain
     text/x-component
     application/javascript
-    application/x-javascript
     application/json
     application/xml
-    application/rss+xml
+    application/xhtml+xml
     application/x-font-ttf
     application/x-font-opentype
     application/vnd.ms-fontobject
-    image/svg+xml;
+    image/svg+xml
+    image/x-icon;
 
   # This should be turned on if you are going to have pre-compressed copies (.gz) of
   # static files available. If not it should be left off as it will cause extra I/O


### PR DESCRIPTION
Adds `application/xhtml+xml` and `image/x-icon` to match the HTML5 Boilerplate .htaccess file and removes MIME types that don't exist in the mime.types file.
