### PR TITLE
Split nginx h5bp server rules into separate files

### DIFF
--- a/nginx/conf/README.md
+++ b/nginx/conf/README.md
@@ -1,0 +1,7 @@
+Component-config files
+----------------------
+
+Each of these files is intended to be included in a server block. Not all of
+the files here are used - they are available to be included as required. The
+`h5bp.conf` file includes the rules which are recommended to always be
+defined.

--- a/nginx/conf/cache-busting.conf
+++ b/nginx/conf/cache-busting.conf
@@ -1,0 +1,10 @@
+# Built-in filename-based cache busting
+
+# https://github.com/h5bp/html5-boilerplate/blob/5370479476dceae7cc3ea105946536d6bc0ee468/.htaccess#L403
+# This will route all requests for /css/style.20120716.css to /css/style.css
+# Read also this: github.com/h5bp/html5-boilerplate/wiki/cachebusting
+# This is not included by default, because it'd be better if you use the build
+# script to manage the file names.
+location ~* (.+)\.(\d+)\.(js|css|png|jpg|jpeg|gif)$ {
+   try_files $uri $1.$3;
+}

--- a/nginx/conf/cross-domain-ajax.conf
+++ b/nginx/conf/cross-domain-ajax.conf
@@ -1,0 +1,2 @@
+# Cross domain AJAX requests
+add_header "Access-Control-Allow-Origin" "*";

--- a/nginx/conf/cross-domain-fonts.conf
+++ b/nginx/conf/cross-domain-fonts.conf
@@ -1,0 +1,4 @@
+# Cross domain webfont access
+location ~* \.(ttf|ttc|otf|eot|woff|font.css)$ {
+    add_header "Access-Control-Allow-Origin" "*";
+}

--- a/nginx/conf/expires.conf
+++ b/nginx/conf/expires.conf
@@ -1,0 +1,42 @@
+# Expire rules for static content
+
+# No default expire rule. This config mirrors that of apache as outlined in the
+# html5-boilerplate .htaccess file. However, nginx applies rules by location,
+# the apache rules are defined by type. A concequence of this difference is that
+# if you use no file extension in the url and serve html, with apache you get an
+# expire time of 0s, with nginx you'd get an expire header of one month in the
+# future (if the default expire rule is 1 month). Therefore, do not use a
+# default expire rule with nginx unless your site is completely static
+
+# cache.appcache, your document html and data
+location ~* \.(?:manifest|appcache|html|xml|json)$ {
+  expires -1;
+  access_log logs/static.log;
+}
+
+# Feed
+location ~* \.(?:rss|atom)$ {
+  expires 1h;
+  add_header Cache-Control "public";
+}
+
+# Favicon
+location ~* \.ico$ {
+  expires 1w;
+  access_log off;
+  add_header Cache-Control "public";
+}
+
+# Media: images, video, audio, HTC, WebFonts
+location ~* \.(?:jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
+  expires 1M;
+  access_log off;
+  add_header Cache-Control "public";
+}
+
+# CSS and Javascript
+location ~* \.(?:css|js)$ {
+  expires 1y;
+  access_log off;
+  add_header Cache-Control "public";
+}

--- a/nginx/conf/h5bp.conf
+++ b/nginx/conf/h5bp.conf
@@ -1,0 +1,6 @@
+# Basic h5bp rules
+
+include conf/expires.conf;
+include conf/x-ua-compatible.conf;
+include conf/cross-domain-fonts.conf;
+include conf/protect-system-files.conf;

--- a/nginx/conf/no-transform.conf
+++ b/nginx/conf/no-transform.conf
@@ -1,0 +1,2 @@
+# Prevent mobile network providers from modifying your site
+add_header "Cache-Control" "no-transform";

--- a/nginx/conf/protect-system-files.conf
+++ b/nginx/conf/protect-system-files.conf
@@ -1,0 +1,9 @@
+# Prevent clients from accessing hidden files (starting with a dot)
+location ~* (^|/)\. {
+    return 403;
+}
+
+# Prevent clients from accessing to backup/config/source files
+location ~* (\.(bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist)|~)$ {
+    return 403;
+}

--- a/nginx/conf/x-ua-compatible.conf
+++ b/nginx/conf/x-ua-compatible.conf
@@ -1,0 +1,2 @@
+# opt-in to the future
+add_header "X-UA-Compatible" "IE=Edge,chrome=1";

--- a/nginx/sites-available/example.com
+++ b/nginx/sites-available/example.com
@@ -17,8 +17,7 @@ server {
   # listen 80 default_server accept_filter=httpready; # for FreeBSD
   listen 80 default_server;
 
-  # listen on the non-www host -- the www-host is declared in www-redirect.conf
-  # here
+  # The host name to respond to
   server_name example.com;
 
   # Path for static files
@@ -30,77 +29,7 @@ server {
   # Custom 404 page
   error_page 404 /404.html;
 
-  # Built-in filename-based cache busting
-  # https://github.com/h5bp/html5-boilerplate/blob/5370479476dceae7cc3ea105946536d6bc0ee468/.htaccess#L403
-  # This will route all requests for /css/style.20120716.css to /css/style.css
-  # Read also this: github.com/h5bp/html5-boilerplate/wiki/cachebusting
-  # This is disabled by default, because it'd be better if you use the build
-  # script to manage the file names.
-  # location ~* (.+)\.(\d+)\.(js|css|png|jpg|jpeg|gif)$ {
-  #    try_files $uri $1.$3;
-  # }
+  # Include the component config parts for h5bp
+  include conf/h5bp.conf;
 
-  # No default expire rule. This config mirrors that of apache as outlined in the
-  # html5-boilerplate .htaccess file. However, nginx applies rules by location, the apache rules
-  # are defined by type. A concequence of this difference is that if you use no file extension in
-  # the url and serve html, with apache you get an expire time of 0s, with nginx you'd get an
-  # expire header of one month in the future (if the default expire rule is 1 month).
-  # Therefore, do not use a default expire rule with nginx unless your site is completely static
-
-  # cache.appcache, your document html and data
-  location ~* \.(?:manifest|appcache|html|xml|json)$ {
-    expires -1;
-    access_log logs/static.log;
-  }
-
-  # Feed
-  location ~* \.(?:rss|atom)$ {
-    expires 1h;
-    add_header Cache-Control "public";
-  }
-
-  # Favicon
-  location ~* \.ico$ {
-    expires 1w;
-    access_log off;
-    add_header Cache-Control "public";
-  }
-
-  # Media: images, video, audio, HTC, WebFonts
-  location ~* \.(?:jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
-    expires 1M;
-    access_log off;
-    add_header Cache-Control "public";
-  }
-
-  # CSS and Javascript
-  location ~* \.(?:css|js)$ {
-    expires 1y;
-    access_log off;
-    add_header Cache-Control "public";
-  }
-
-  # opt-in to the future
-  add_header "X-UA-Compatible" "IE=Edge,chrome=1";
-
-  # Cross domain AJAX requests
-  # add_header "Access-Control-Allow-Origin" "*";
-
-  # Cross domain webfont access
-  location ~* \.(ttf|ttc|otf|eot|woff|font.css)$ {
-      add_header "Access-Control-Allow-Origin" "*";
-  }
-
-  # Prevent mobile network providers from modifying your site
-  # add_header "Cache-Control" "no-transform";
-
-  # Prevent clients from accessing hidden files (starting with a dot)
-  location ~* (^|/)\. {
-      return 403;
-  }
-
-  # Prevent clients from accessing to backup/config/source files
-  location ~* (\.(bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist)|~)$ {
-      return 403;
-  }
 }


### PR DESCRIPTION
One of the main reasons I originally suggested to move each server config into a separate folder was to permit restructuring the nginx config into multiple files. Using multiple files makes it a lot easier to a) mix-and-match rules in whatever way is required and b) keep the h5bp server rules in one place - and therefore avoid repetition (especially in the case of multiple vhosts).

I've quickly gone through those changes right now, and would like to check if anyone has any objections to structuring the config files in this way before merging.
