### PR TITLE
Use the mime module exposed in Connect or Express

### DIFF
--- a/node/node.js
+++ b/node/node.js
@@ -143,8 +143,11 @@ h5bp.server = function (serverConstructor, options) {
          this.ieEdgeChromeFrameHeader()
       //,this.expireHeaders(options.maxAge),
       // this.removeEtag(),
-      // this.setContentType(require('mime'))
-       ];
+      // this.setContentType(   serverConstructor.mime        // connect exposes the mime module as connect.mime
+      //                     || serverConstructor.static.mime // both connect.static and express.static expose the mime module
+      //                     || options.mime                  // use the mime module provided by user
+      //                     || require('mime'))              // require mime
+       ]; 
    // express/connect
    if (server.use) {
       stack.unshift(serverConstructor.logger('dev'));


### PR DESCRIPTION
Instead of making the user send the mime module in as an argument, use the mime modules exposed by Connect an Express and only make the user send in mime if using HTTP and not Connect/Express.
