### PR TITLE
Hide nginx version

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,6 +40,9 @@ http {
   # Click tracking!
   access_log   logs/access.log  main;
 
+  # Hide nginx version
+  server_tokens off;
+
   # ~2 seconds is often enough for HTML/CSS, but connections in
   # Nginx are cheap, so generally it's safe to increase it
   keepalive_timeout 20;


### PR DESCRIPTION
Hide nginx version from server headers, it's matter of security and there is no good reason to show it.
