### PR TITLE
Update gzip_disable option to match best practice

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -78,7 +78,7 @@ http {
   # a specific directory:
   # gzip_static on;
 
-  gzip_disable        "MSIE [1-6]\.";
+  gzip_disable        "msie6";
   gzip_vary           on;
 
   include sites-enabled/*;


### PR DESCRIPTION
Nginx recommend to use the string `msie6` instead of the previously recommended regex.

The string matches the same stuff as the regex, but is faster according to their docs.

See: http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable
