### PR TITLE
Add Gzip support for Node.js configuration

### DIFF
--- a/node/lib/h5bp.js
+++ b/node/lib/h5bp.js
@@ -19,6 +19,16 @@
 
         reDubDubDub = /^www\./;
 
+    // Gzip methods
+    var zlib = require('zlib'),
+        methods = {
+            gzip: zlib.createGzip,
+            deflate: zlib.createDeflate
+        },
+        filter = function(req, res){
+            return /json|text|javascript/.test(res.getHeader('Content-Type'));
+        };
+
     // default mime types associations.
     // exposed here for extension or any useful purpose.
     // @type {Object}
@@ -183,8 +193,75 @@
                 // @TODO: read specified asset dirs concat everything.
 
                 // Gzip compression
-                // @TODO: we should be able to use the node gzip native bindings.
-                if (options.compress) {}
+                // Based on Connect's compress() middleware
+                if (options.compress) {
+                    (function (options) {
+                        var accept = req.headers['accept-encoding'],
+                            write = res.write,
+                            end = res.end,
+                            stream,
+                            method;
+
+                        if (!accept) { return; }
+
+                        // compression method
+                        // default to gzip
+                        if ('*' == accept.trim()) method = 'gzip';
+                        if (!method) {
+                            for (var i = 0, len = names.length; i < len; ++i) {
+                                if (~accept.indexOf(names[i])) {
+                                    method = names[i];
+                                    break;
+                                }
+                            }
+                        }
+                        if (!method) return;
+
+                        // vary
+                        res.setHeader('Vary', 'Accept-Encoding');
+
+                        // proxy
+                        res.write = function(chunk, encoding){
+                            if (!this.headerSent) this._implicitHeader();
+                            return stream ? stream.write(new Buffer(chunk, encoding)) : write.call(res, chunk, encoding);
+                        };
+                        res.end = function(chunk, encoding){
+                            if (chunk) this.write(chunk, encoding);
+                            return stream ? stream.end() : end.call(res);
+                        };
+
+                        res.on('header', function(){
+                            var encoding = res.getHeader('Content-Encoding') || 'identity';
+                    
+                            // already encoded
+                            if ('identity' != encoding) return; 
+                    
+                            // default request filter
+                            if (!filter(req, res)) return;
+                    
+                            // head
+                            if ('HEAD' == req.method) return;
+                    
+                            // compression stream
+                            stream = methods[method](options);
+                    
+                            // header fields
+                            res.setHeader('Content-Encoding', method);
+                            res.removeHeader('Content-Length');
+                    
+                            // compression
+                            stream.on('data', function(chunk){
+                                write.call(res, chunk);
+                            });
+                            stream.on('end', function(){
+                                end.call(res);
+                            });
+                            stream.on('drain', function() {
+                                res.emit('drain');
+                            });
+
+                    })(opts.compress);
+                }
 
                 // Expires headers (for better cache control)
                 // These are pretty far-future expires headers.


### PR DESCRIPTION
Add Gzip support for Node.js configuration, based on Connect's compress() middleware.
