### PR TITLE
Uncapitalised "Edge" to match notation in boilerplate

### DIFF
--- a/apache/.htaccess
+++ b/apache/.htaccess
@@ -19,7 +19,7 @@
 # Use ChromeFrame if it's installed for a better experience for the poor IE folk
 
 <IfModule mod_headers.c>
-  Header set X-UA-Compatible "IE=Edge,chrome=1"
+  Header set X-UA-Compatible "IE=edge,chrome=1"
   # mod_headers can't match by content-type, but we don't want to send this header on *everything*...
   <FilesMatch "\.(appcache|crx|css|eot|gif|htc|ico|jpe?g|js|m4a|m4v|manifest|mp4|oex|oga|ogg|ogv|otf|pdf|png|safariextz|svg|svgz|ttf|vcf|webm|webp|woff|xml|xpi)$">
     Header unset X-UA-Compatible


### PR DESCRIPTION
Uncapitalised "Edge" to match notation in boilerplate index.html and official suggestion (http://msdn.microsoft.com/en-us/library/jj676915(v=vs.85).aspx)
