### PR TITLE
Fix charset_types as mime.types is updated

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -32,6 +32,9 @@ http {
   # And the fallback mime-type
   default_type application/octet-stream;
 
+  # Update charset_types due to updated mime.types
+  charset_types text/html text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml text/css application/javascript application/json
+
   # Format for our log files
   log_format  main '$remote_addr - $remote_user [$time_local]  $status '
     '"$request" $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
The default Nginx `charset_types` [1] is 

```
text/html text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml
```

Since the `mime.types` is updated and `application/javascript application/json` are now being used instead of `application/x-javascript`, if the `charset_types` is not updated, then `charset` directive will not work as expected.

Besides, I have added `text/css` for better handling of non-ASCII in css file. [3]

[1] http://wiki.nginx.org/HttpCharsetModule#charset_types
[2] http://forum.nginx.org/read.php?2,52360,52370#msg-52370
[3] http://trac.nginx.org/nginx/ticket/312
