### PR TITLE
Fix for caching and removing pointless versioning rewrites.

### DIFF
--- a/iis/dotnet 4/mvc4 & mvc4api/web.config
+++ b/iis/dotnet 4/mvc4 & mvc4api/web.config
@@ -76,8 +76,12 @@
         <modules runAllManagedModulesForAllRequests="true" />
         <urlCompression doStaticCompression="true" />
         <staticContent>
-            <!-- Set expire headers to 30 days for static content-->
+    		<!-- Static File Cache Control
             <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00" />
+            You should set the clientCache control within a location to avoid caching elements such as appcache and manifest
+            Better still make use of something like http://getcassette.net to handle your versioning.
+            More information on the client cache can be found here http://www.iis.net/configreference/system.webserver/staticcontent/clientcache
+            -->
             <!-- use utf-8 encoding for anything served text/plain or text/html -->
             <remove fileExtension=".css" />
             <mimeMap fileExtension=".css" mimeType="text/css" />
@@ -263,22 +267,6 @@
                     <action type="Redirect" url="http://www.example.com/{R:0}" redirectType="Permanent" /> 
                 </rule> 
             -->
-            <!--
-            ### Built-in filename-based cache busting
-            
-            If you're not using the build script to manage your filename version revving,
-            you might want to consider enabling this, which will route requests for
-            /css/style.20110203.css to /css/style.css
-
-            To understand why this is important and a better idea than all.css?v1231,
-            read: github.com/h5bp/html5-boilerplate/wiki/Version-Control-with-Cachebusting
-
-                <rule name="Cachebusting">
-                    <match url="^(.+)\.\d+(\.(js|css|png|jpg|gif)$)" />
-                    <action type="Rewrite" url="{R:1}{R:2}" />
-                </rule>
-            
-            </rules>
         </rewrite>-->
 
     </system.webServer>


### PR DESCRIPTION
Crap client cache defaults in config that I for some reason carried over when I rebuilt the lot.
Removed versioning rewriting from file, this is .net not php. Documentation linked was broken.
Default caching causes appcache and manifest to be cached for 30days which breaks how these work. 
