### PR TITLE
Fix JavaScript not being gzipped on IIS

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -85,7 +85,7 @@ mode
 <remove fileExtension=".css" />
 <mimeMap fileExtension=".css" mimeType="text/css" />
 <remove fileExtension=".js" />
-<mimeMap fileExtension=".js" mimeType="application/javascript" />
+<mimeMap fileExtension=".js" mimeType="text/javascript" />
 <remove fileExtension=".json" />
 <mimeMap fileExtension=".json" mimeType="application/json" />
 <remove fileExtension=".rss" />

--- a/iis/dotnet 3/web.config
+++ b/iis/dotnet 3/web.config
@@ -102,7 +102,7 @@
             <remove fileExtension=".css" />
             <mimeMap fileExtension=".css" mimeType="text/css" />
             <remove fileExtension=".js" />
-            <mimeMap fileExtension=".js" mimeType="application/javascript" />
+            <mimeMap fileExtension=".js" mimeType="text/javascript" />
             <remove fileExtension=".json" />
             <mimeMap fileExtension=".json" mimeType="application/json" />
             <remove fileExtension=".rss" />

--- a/iis/dotnet 4/mvc4 & mvc4api/web.config
+++ b/iis/dotnet 4/mvc4 & mvc4api/web.config
@@ -82,7 +82,7 @@
             <remove fileExtension=".css" />
             <mimeMap fileExtension=".css" mimeType="text/css" />
             <remove fileExtension=".js" />
-            <mimeMap fileExtension=".js" mimeType="application/javascript" />
+            <mimeMap fileExtension=".js" mimeType="text/javascript" />
             <remove fileExtension=".json" />
             <mimeMap fileExtension=".json" mimeType="application/json" />
             <remove fileExtension=".rss" />

--- a/iis/dotnet 4/webforms/web.config
+++ b/iis/dotnet 4/webforms/web.config
@@ -64,7 +64,7 @@
             <remove fileExtension=".css" />
             <mimeMap fileExtension=".css" mimeType="text/css" />
             <remove fileExtension=".js" />
-            <mimeMap fileExtension=".js" mimeType="application/javascript" />
+            <mimeMap fileExtension=".js" mimeType="text/javascript" />
             <remove fileExtension=".json" />
             <mimeMap fileExtension=".json" mimeType="application/json" />
             <remove fileExtension=".rss" />


### PR DESCRIPTION
IIS requires the mime type of JavaScript set to text/javascript for gzip compression to kick in.

Discussion about the issue: http://bit.ly/stPqn1 (including comments from Jeff Atwood)

Fix discussed in further detail: http://bit.ly/d0rtWy
