### PR TITLE
Fix IE SSL issues when KeepAlive is enabled

### DIFF
--- a/apache/.htaccess
+++ b/apache/.htaccess
@@ -540,5 +540,5 @@ FileETag None
 # possible disadvantages!
 
 # <IfModule mod_headers.c>
-#    Header set Connection Keep-Alive
+#    Header set Connection Keep-Alive env=!nokeepalive
 # </IfModule>


### PR DESCRIPTION
By default, mod_ssl includes a BrowserMatch directive that turns off KeepAlive for all IE SSL traffic. The user can see garbage data when the Connection header is set to Keep-Alive in the htaccess and a user is re-directed using HTTP/1.0 on SSL in IE.

Related #107

Note: There is a fix that should be applied to the Apache ssl.conf file to go along side this change that enables KeepAlive for newer versions of IE (that work). 

Reference http://www.alexmeyer.com/linux/apachekeepalive.html

``` Apache
NameVirtualHost *:443
<VirtualHost *:443>
    SSLEngine on
    SSLCertificateFile /etc/apache2/ssl/foo.com-cert.pem
    SSLCertificateKeyFile /etc/apache2/ssl/foo.com-key.pem
    SSLCACertificateFile /etc/apache2/ssl/cacert.pem

    SetEnvIf User-Agent ".*MSIE [2-6].*" \
        nokeepalive ssl-unclean-shutdown \
        downgrade-1.0 force-response-1.0

    SetEnvIf User-Agent ".*MSIE [17-9].*" \
        ssl-unclean-shutdown
</VirtualHost>
```

To summarize

`IE + SSL =` :poop:
