### PR TITLE
Security enhancements for ligtthpd config

### DIFF
--- a/lighttpd/lighttpd.conf
+++ b/lighttpd/lighttpd.conf
@@ -15,8 +15,9 @@ server.document-root = "/var/www/sites/go/here/"
 # Disable directory listing for security
 server.dir-listing = "disable"
 
-# Disable display of version number
-server.tag = "lighttpd"
+# Avoid revealing that it's a ligtthpd server and, most importantly, disable
+# display of server version.
+server.tag = ""
 
 # Modules to load
 # at least mod_access and mod_accesslog should be loaded


### PR DESCRIPTION
Added lines in the lighttpd config to:
- Disable the server from listing the directory, for directories without an index file
- Removed server tag, in comparison with displaying webserver name and version.
