### PR TITLE
HSTS Support

### DIFF
--- a/apache/.htaccess
+++ b/apache/.htaccess
@@ -333,26 +333,21 @@ AddDefaultCharset utf-8
 #    RewriteRule ^ https://example-domain-please-change-me.com%{REQUEST_URI} [R=301,L]
 # </IfModule>
 
-# Notice the browser to not even try an HTTP connection if your default is HTTPS.
-# See https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
-# and http://tools.ietf.org/html/draft-ietf-websec-strict-transport-sec-14#section-6.1
-# <IfModule mod_headers.c>
-#    Header set Strict-Transport-Security "max-age=16070400; includeSubDomains"
-# </IfModule>
-
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-# Force client-side SSL redirection.
+# Force client-side SSL redirection (HSTS).
 
 # If a user types "example.com" in his browser, the above rule will redirect him
 # to the secure version of the site. That still leaves a window of opportunity
 # (the initial HTTP connection) for an attacker to downgrade or redirect the
 # request. The following header ensures that browser will ONLY connect to your
 # server via HTTPS, regardless of what the users type in the address bar.
+# Remove the `includeSubDomains` setting if subdomains are not secured by HTTPS.
 # http://www.html5rocks.com/en/tutorials/security/transport-layer-security/
+# http://tools.ietf.org/html/draft-ietf-websec-strict-transport-sec-14#section-6.1
 
 # <IfModule mod_headers.c>
-#    Header set Strict-Transport-Security max-age=16070400;
+#    Header set Strict-Transport-Security "max-age=16070400; includeSubDomains"
 # </IfModule>
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
In addition of the HTTPS redirect, adding HSTS support will even skip this redirect the next time a supporting browser asks for a non-secured resource.

We potentially gain an HTTP query per non-HTTPS requested resource and smoothly increased security and privacy.

The value is set accordingly to the recommended value in the spec.

If you agree with this proposal, the same change can be propagated in other boilerplate files (like Nginx etc.).

It's a follow-up of h5bp/html5-boilerplate#1365.
