### PR TITLE
Fixed redirect for localhost in option 2 rewrite

### DIFF
--- a/apache/.htaccess
+++ b/apache/.htaccess
@@ -253,6 +253,8 @@ AddDefaultCharset utf-8
 # <IfModule mod_rewrite.c>
 #    RewriteCond %{HTTPS} !=on
 #    RewriteCond %{HTTP_HOST} !^www\..+$ [NC]
+#    RewriteCond %{HTTP_HOST} !=localhost [NC]
+#    RewriteCond %{HTTP_HOST} !=127.0.0.1
 #    RewriteRule ^ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 # </IfModule>
 


### PR DESCRIPTION
In the .htaccess file option 2 rewrite rules, which prepends "www." to
URLs, could break applications running on a local environment. If
option 2 was enabled, http://localhost or http://127.0.0.1 would
redirect to http://www.localhost or http://www.127.0.0.1 which caused
an error and prevents the app from being tested locally. Added
exceptions to the rewrite conditions to prevent this.
