### PR TITLE
Added Microsoft MIME Types + Force Download Options

### DIFF
--- a/apache/.htaccess
+++ b/apache/.htaccess
@@ -175,8 +175,20 @@ Options -MultiViews
     AddType text/vtt                                    vtt
     AddType text/x-component                            htc
     AddType text/x-vcard                                vcf
+    AddType application/vnd.openxmlformats              docx pptx xlsx xltx xltm dotx potx ppsx
+ </IfModule>
+ 
 
-</IfModule>
+# ------------------------------------------------------------------------------
+# | Force Download for several filetypes                                       |
+# ------------------------------------------------------------------------------
+
+# example for excel files
+<FilesMatch "\.(xlsx)$">
+  ForceType application/octet-stream
+  Header set Content-Disposition attachment
+</FilesMatch> 
+
 
 # ------------------------------------------------------------------------------
 # | UTF-8 encoding                                                             |


### PR DESCRIPTION
Adding microsoft MIME types and Force download for some files avoid bugs (for example, xlsx opened in Firefox, etc.).

See references : http://www.amember.com/forum/threads/force-file-downloads-with-htaccess.14980/
http://www.saelboat.com/blog/2012/12/htaccess-guide-force-downloads-of-mp3s-pdfs-and-other-media-files-299
